### PR TITLE
Make 1.11 compatible

### DIFF
--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -1,7 +1,8 @@
 from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.options import (ModelAdmin, InlineModelAdmin,
     csrf_protect_m, models, transaction, all_valid,
-    PermissionDenied, unquote, escape, Http404, reverse)
+    PermissionDenied, unquote, Http404, reverse)
+from django.utils.html import escape
 # Fix to make Django 1.5 compatible, maintain backwards compatibility
 try:
     from django.contrib.admin.options import force_unicode

--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -1,8 +1,9 @@
 from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.options import (ModelAdmin, InlineModelAdmin,
     csrf_protect_m, models, transaction, all_valid,
-    PermissionDenied, unquote, Http404, reverse)
+    PermissionDenied, unquote, reverse)
 from django.utils.html import escape
+from django.http import Http404
 # Fix to make Django 1.5 compatible, maintain backwards compatibility
 try:
     from django.contrib.admin.options import force_unicode

--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -2,8 +2,19 @@ from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.options import (ModelAdmin, InlineModelAdmin,
     csrf_protect_m, models, transaction, all_valid,
     PermissionDenied, unquote, reverse)
-from django.utils.html import escape
-from django.http import Http404
+
+# Maintain backwards compatibility   
+try:
+    from django.contrib.admin.options import escape
+except ImportError:
+    from django.utils.html import escape
+
+# Maintain backwards compatibility
+try:
+    from django.contrib.admin.options import Http404
+except ImportError:
+    from django.http import Http404
+
 # Fix to make Django 1.5 compatible, maintain backwards compatibility
 try:
     from django.contrib.admin.options import force_unicode


### PR DESCRIPTION
@sandinmyjoints 

# What/Why
* Some imports moved around as of django 1.11, so account for that here