### PR TITLE
Do not assume that nested formsets have dependency_has_changed

### DIFF
--- a/nested_inlines/forms.py
+++ b/nested_inlines/forms.py
@@ -45,7 +45,9 @@ class NestedModelFormMixin(NestedFormMixin):
         # TODO this should be generalized
         if hasattr(self, 'nested_formsets'):
             for f in self.nested_formsets:
-                if f.dependency_has_changed():
+                # Some of these formsets may not be nested formsets from this library
+                if hasattr(f, 'dependency_has_changed') \
+                        and f.dependency_has_changed():
                     return True
         return False
 


### PR DESCRIPTION
@sandinmyjoints 

# What/Why
* Some nested formsets could be automatically generated from a related model by the django admin, in which case they will not have the `dependency_has_changed` method, throwing an error when trying to save in the admin